### PR TITLE
Ensure waybar launches and use zsh in Alacritty

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -62,7 +62,7 @@
       mainBar = {
         layer    = "top";
         position = "top";
-        modules-left  = [ "niri/workspaces" ];   # intégration directe avec Niri :contentReference[oaicite:1]{index=1}
+        modules-left  = [ ];
         modules-center = [ ];
         modules-right = [ "clock" "cpu" "memory" ];
       };
@@ -81,6 +81,8 @@ programs.alacritty = {
     window.padding = { x = 6; y = 6; };
     window.decorations = "none";
     font.size = 11;
+    shell.program = "${pkgs.zsh}/bin/zsh";
+    shell.args = [ "-l" ];
     colors.primary.background = "#1e1e2e";
     colors.primary.foreground = "#cdd6f4";
   };

--- a/modules/niri/config.kdl
+++ b/modules/niri/config.kdl
@@ -11,7 +11,6 @@ output "*" {
   focus-at-startup
 }
 
-spawn-at-startup "waybar"
 spawn-at-startup "alacritty"
 
 binds {


### PR DESCRIPTION
## Summary
- Remove Niri-specific waybar module to allow bar to start
- Default Alacritty to zsh login shell
- Let home-manager manage waybar instead of spawning from Niri

## Testing
- `nixfmt home-manager/home.nix modules/niri/config.kdl` *(fails: command not found)*
- `nix shell nixpkgs#nixfmt -c nixfmt home-manager/home.nix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0e811d4832f9ebaac98b0e68af0